### PR TITLE
QDB-18136 - Remove `vm.swappiness=0` parameter

### DIFF
--- a/qdb-server/sysctl.d/99-quasardb.conf
+++ b/qdb-server/sysctl.d/99-quasardb.conf
@@ -55,6 +55,3 @@ vm.dirty_bytes            = 1073741824  #   1 GiB
 
 # NUMA: prevent zone reclaim surprises on multi-socket boxes.
 vm.zone_reclaim_mode = 0
-
-# Only swap when we actually reach near OOM
-vm.swappiness = 0


### PR DESCRIPTION
Story details: https://app.shortcut.com/quasardb/story/18136